### PR TITLE
Implement proposals as template partials

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -30,6 +30,11 @@
       {% image page.test_image width-783 alt="original" %}
     </picture>
 
+    <h3>Template partial</h3>
+
+    {# resize_rule does nothing, it’s just there as an illustration #}
+    {% include "webp_picture.html" with img=page.test_image alt="original" resize_rule="width-782" %}
+
     <h3>Template tag</h3>
 
     {# {% picture_webp page.test_image width-783@768w alt="original" %} #}
@@ -60,4 +65,9 @@
         src="{{ image_desktop_fallback.url }}" alt="original"
       >
     </picture>
+
+    <h3>Template partial</h3>
+
+    {# resize_rule does nothing, it’s just there as an illustration #}
+    {% include "responsive_picture.html" with img=page.test_image alt="original" sizes="(max-width: 768px) 688px, 924px" resize_rule="width-792 width-392" %}
 {% endblock %}

--- a/wagtail_picture/templates/responsive_picture.html
+++ b/wagtail_picture/templates/responsive_picture.html
@@ -1,5 +1,5 @@
 {% load wagtailimages_tags %}
-{# width- resize rules shouldn’t be hard-coded, but there is no way for us to do provide it via Django Templates’ include, so we have to pretend #}
+{# width- resize rules shouldn’t be hard-coded, but there is no way for us to provide it via Django Templates’ include, so we have to pretend #}
 <picture>
   {% image img width-792 format-webp as image_desktop_webp %}
   {% image img width-392 format-webp as image_mobile_webp %}
@@ -13,6 +13,7 @@
   <source
     srcset="{{ image_desktop_fallback.url }} {{ image_desktop_fallback.width }}w, {{ image_mobile_fallback.url}} {{ image_mobile_fallback.width }}w"
     sizes="{{ sizes }}"
+    {# This is very quick and dirty. In a template tag we should be able to use the actual file mime type. #}
     type="{% if img.file.name.lower|slice:"-3:" == "png" %}image/png{% else %}image/jpeg{% endif %}"
   >
   <img src="{{ image_desktop_fallback.url }}" width="{{ image_desktop_fallback.width }}" height="{{ image_desktop_fallback.height }}" alt="{{ alt }}" />

--- a/wagtail_picture/templates/responsive_picture.html
+++ b/wagtail_picture/templates/responsive_picture.html
@@ -1,0 +1,19 @@
+{% load wagtailimages_tags %}
+{# width- resize rules shouldn’t be hard-coded, but there is no way for us to do provide it via Django Templates’ include, so we have to pretend #}
+<picture>
+  {% image img width-792 format-webp as image_desktop_webp %}
+  {% image img width-392 format-webp as image_mobile_webp %}
+  {% image img width-792 as image_desktop_fallback %}
+  {% image img width-392 as image_mobile_fallback %}
+  <source
+    srcset="{{ image_desktop_webp.url }} {{ image_desktop_webp.width }}w, {{ image_mobile_webp.url}} {{ image_mobile_webp.width }}w"
+    sizes="{{ sizes }}"
+    type="image/webp"
+  >
+  <source
+    srcset="{{ image_desktop_fallback.url }} {{ image_desktop_fallback.width }}w, {{ image_mobile_fallback.url}} {{ image_mobile_fallback.width }}w"
+    sizes="{{ sizes }}"
+    type="{% if img.file.name.lower|slice:"-3:" == "png" %}image/png{% else %}image/jpeg{% endif %}"
+  >
+  <img src="{{ image_desktop_fallback.url }}" width="{{ image_desktop_fallback.width }}" height="{{ image_desktop_fallback.height }}" alt="{{ alt }}" />
+</picture>

--- a/wagtail_picture/templates/webp_picture.html
+++ b/wagtail_picture/templates/webp_picture.html
@@ -1,0 +1,8 @@
+{% load wagtailimages_tags %}
+{# width-782 shouldn’t be hard-coded, but there is no way for us to do provide it via Django Templates’ include, so we have to pretend #}
+<picture>
+  {% image img format-webp width-782 as webp_image %}
+  <source srcset="{{ webp_image.url }}" type="image/webp">
+  {% image img width-782 alt=alt %}
+</picture>
+


### PR DESCRIPTION
This implements "template partials" versions of the two proposals for new template tags. This is mostly intended to help review the output markup – although the template partials versions do work, they have big limitations compared to template tags.